### PR TITLE
Update travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
-sudo: required
+addons:
+  apt:
+    packages:
+      - expect-dev  # provides unbuffer utility
+      - python-lxml # because pip installation is slow
+
 language: python
 
 python:


### PR DESCRIPTION
Follow OCA/maintainer-quality-tools#187 and use addons/apt/package directive to
install our build dependencies. This allows using container based Travis builds
(which should be faster).